### PR TITLE
remove sha1 key-exchange mechanisms from default

### DIFF
--- a/libraries/get_ssh_kex.rb
+++ b/libraries/get_ssh_kex.rb
@@ -27,12 +27,12 @@ class Chef
         weak_kex = weak_kex ? 'weak' : 'default'
 
         kex_59 = {}
-        kex_59.default = 'diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-        kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group1-sha1'
+        kex_59.default = 'diffie-hellman-group-exchange-sha256'
+        kex_59['weak'] = kex_59['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
         kex_66 = {}
-        kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1'
-        kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group1-sha1'
+        kex_66.default = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
+        kex_66['weak'] = kex_66['default'] + ',diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1'
 
         # determine the kex for the operating system
         kex = kex_59

--- a/spec/recipes/client_spec.rb
+++ b/spec/recipes/client_spec.rb
@@ -49,6 +49,10 @@ describe 'ssh-hardening::client' do
 
   it 'disables weak kexs' do
     expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+      .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+    expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+      .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
+    expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
       .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
   end
 
@@ -103,6 +107,10 @@ describe 'ssh-hardening::client' do
 
     it 'allows weak kexs on the client' do
       expect(chef_run).to render_file('/etc/ssh/ssh_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+      expect(chef_run).to render_file('/etc/ssh/ssh_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
+      expect(chef_run).to render_file('/etc/ssh/ssh_config')
         .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
     end
 
@@ -119,6 +127,10 @@ describe 'ssh-hardening::client' do
     end
 
     it 'does not allow weak kexs on the client' do
+      expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+      expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
       expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
         .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
     end
@@ -171,6 +183,10 @@ describe 'ssh-hardening::client' do
 
       it 'still does not allow weak kexs' do
         expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+        expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
+        expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
           .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
       end
 
@@ -194,6 +210,10 @@ describe 'ssh-hardening::client' do
       end
 
       it 'allows weak kexs on the client' do
+        expect(chef_run).to render_file('/etc/ssh/ssh_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+        expect(chef_run).to render_file('/etc/ssh/ssh_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
         expect(chef_run).to render_file('/etc/ssh/ssh_config')
           .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
       end
@@ -235,6 +255,10 @@ describe 'ssh-hardening::client' do
       end
 
       it 'still does not allow weak kexs' do
+        expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+        expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
         expect(chef_run).not_to render_file('/etc/ssh/ssh_config')
           .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
       end

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -57,6 +57,10 @@ describe 'ssh-hardening::server' do
 
   it 'disables weak kexs' do
     expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+      .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+    expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+      .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
+    expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
       .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
   end
 
@@ -112,6 +116,10 @@ describe 'ssh-hardening::server' do
 
     it 'enables weak kexs on the server' do
       expect(chef_run).to render_file('/etc/ssh/sshd_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+      expect(chef_run).to render_file('/etc/ssh/sshd_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
+      expect(chef_run).to render_file('/etc/ssh/sshd_config')
         .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
     end
 
@@ -129,6 +137,10 @@ describe 'ssh-hardening::server' do
     end
 
     it 'does not enable weak kexs on the server' do
+      expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+      expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+        .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
       expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
         .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
     end
@@ -183,6 +195,10 @@ describe 'ssh-hardening::server' do
 
       it 'still does not allow weak kexs' do
         expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+        expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
+        expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
           .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
       end
 
@@ -207,6 +223,10 @@ describe 'ssh-hardening::server' do
       end
 
       it 'allows weak kexs' do
+        expect(chef_run).to render_file('/etc/ssh/sshd_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+        expect(chef_run).to render_file('/etc/ssh/sshd_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
         expect(chef_run).to render_file('/etc/ssh/sshd_config')
           .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
       end
@@ -249,6 +269,10 @@ describe 'ssh-hardening::server' do
       end
 
       it 'still does not allow weak kexs' do
+        expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group14-sha1\b/)
+        expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
+          .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group-exchange-sha1\b/)
         expect(chef_run).not_to render_file('/etc/ssh/sshd_config')
           .with_content(/KexAlgorithms [^#]*\bdiffie-hellman-group1-sha1\b/)
       end


### PR DESCRIPTION
Move diffie-hellman-group14-sha1 and diffie-hellman-group-exchange-sha1 to 'weak' KEX mechanisms.
    
References:
* https://stribika.github.io/2015/01/04/secure-secure-shell.html
* https://github.com/TelekomLabs/chef-ssh-hardening/issues/64
