### PR TITLE
bugfix: adjust travis to work with chef12/ruby2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,15 @@ rvm:
 - 1.9.3
 - 2.0.0
 - 2.1.3
+gemfile:
+- Gemfile
+- gemfile.chef-11
 language: ruby
 bundler_args: "--without development integration openstack"
 notifications:
   slack:
     secure: bOxdT8KjXuWpBaNvMsf1zGcBRS5Ua3ESYcBWUEXXKE+f+AatmATCdynHq1QJBzE6NtWcGvxlacF4oA3FMmMhJZW9PF3igmYK2TC/aF8TXQ+nE8uzibkj+BphI6/so6TnXCPxoCp6TQ8gZm9cWyj1M4gnFJiZx9eYMVKCIOSRU/0=
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gem 'chef',       '>= 12.0'
 
 group :test do
   gem 'rake'
-  gem 'chefspec',   '~> 4.1.1'
-  gem 'foodcritic', '~> 3.0'
+  gem 'chefspec',   '~> 4.2.0'
+  gem 'foodcritic', '~> 4.0'
   gem 'thor-foodcritic'
-  gem 'rubocop',    '~> 0.27.0'
+  gem 'rubocop',    '~> 0.28.0'
   gem 'coveralls',  require: false
 end
 

--- a/gemfile.chef-11
+++ b/gemfile.chef-11
@@ -10,7 +10,7 @@ group :test do
   gem 'chefspec',   '~> 4.1.1'
   gem 'foodcritic', '~> 3.0'
   gem 'thor-foodcritic'
-  gem 'rubocop',    '~> 0.27.0'
+  gem 'rubocop',    '~> 0.28.0'
   gem 'coveralls',  require: false
 end
 

--- a/gemfile.chef-11
+++ b/gemfile.chef-11
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 3.0'
-gem 'chef',       '>= 12.0'
+gem 'chef',       '~> 11.16'
 
 group :test do
   gem 'rake'


### PR DESCRIPTION
for ruby 2.0 and greater, test with chef 11 and 12 (or greater). for ruby 1.9 (or before), don't test chef 12 as it requires ruby 2.0 to work:

https://www.chef.io/blog/2014/11/25/ruby-1-9-3-eol-and-chef-12/
Signed-off-by: Dominik Richter <dominik.richter@gmail.com>