### PR TITLE
fix typo in opensshdconf.erb, remove trailing whitespace

### DIFF
--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -3,9 +3,9 @@
 <% end %>
 #---
 
-# This is the ssh client system-wide configuration file. 
+# This is the ssh client system-wide configuration file.
 # See sshd_config(5) for more information on any settings used. Comments will be added only to clarify why a configuration was chosen.
-# 
+#
 # Created for OpenSSH v5.9
 
 # Basic configuration
@@ -46,7 +46,7 @@ Protocol 2
 # Make sure sshd checks file modes and ownership before accepting logins. This prevents accidental misconfiguration.
 StrictModes yes
 
-# Logging, obsoletes QuietMode and FascistLogging 
+# Logging, obsoletes QuietMode and FascistLogging
 SyslogFacility AUTH
 LogLevel VERBOSE
 
@@ -57,15 +57,15 @@ LogLevel VERBOSE
 # CBC: is true if you want to connect with OpenSSL-base libraries
 # eg ruby Net::SSH::Transport::CipherFactory requires cbc-versions of the given openssh ciphers to work
 # -- see: (http://net-ssh.github.com/net-ssh/classes/Net/SSH/Transport/CipherFactory.html)
-# 
+#
 <% if @cipher %>
 Ciphers <%= @cipher %>
 <% end %>
 
 # **Hash algorithms** -- Make sure not to use SHA1 for hashing, unless it is really necessary.
-# Weak HMAC is sometimes required if older package versions are used 
+# Weak HMAC is sometimes required if older package versions are used
 # eg Ruby's Net::SSH at around 2.2.* doesn't support sha2 for hmac, so this will have to be set true in this case.
-# 
+#
 <% if @mac %>
 MACs <%= @mac %>
 <% end %>
@@ -175,11 +175,11 @@ PrintLastLog <%= ((@node['ssh']['print_last_log']) ? 'yes' : 'no' ) %>
 #ChrootDirectory none
 #ChrootDirectory /home/%u
 
-# Configuratoin, in case SFTP is used
+# Configuration, in case SFTP is used
 ## override default of no subsystems
 ## Subsystem sftp /opt/app/openssh5/libexec/sftp-server
 #Subsystem sftp internal-sftp -l VERBOSE
-# 
+#
 ## These lines must appear at the *end* of sshd_config
 #Match Group sftponly
 #ForceCommand internal-sftp -l VERBOSE


### PR DESCRIPTION
Fixed typo in configuration file + removed trailing whitespace