### PR TITLE
Allow deny users to be managed from attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,6 +59,10 @@ default['ssh']['allow_root_with_key']     = false   # sshd
 default['ssh']['allow_tcp_forwarding']    = false   # sshd
 default['ssh']['allow_agent_forwarding']  = false   # sshd
 default['ssh']['use_pam']                 = false   # sshd
+default['ssh']['deny_users']              = []      # sshd
+default['ssh']['allow_users']             = []      # sshd
+default['ssh']['deny_groups']             = []      # sshd
+default['ssh']['allow_groups']            = []      # sshd
 default['ssh']['print_motd']              = false   # sshd
 default['ssh']['print_last_log']          = false   # sshd
 # set this to nil to let us detect the attribute based on the node platform

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -93,7 +93,11 @@ template '/etc/ssh/sshd_config' do
     mac: SshMac.get_macs(node, node['ssh']['server']['weak_hmac']),
     kex: SshKex.get_kexs(node, node['ssh']['server']['weak_kex']),
     cipher: SshCipher.get_ciphers(node, node['ssh']['server']['cbc_required']),
-    use_priv_sep: node['ssh']['use_privilege_separation'] || UsePrivilegeSeparation.get(node)
+    use_priv_sep: node['ssh']['use_privilege_separation'] || UsePrivilegeSeparation.get(node),
+    deny_users: node['ssh']['deny_users'],
+    allow_users: node['ssh']['allow_users'],
+    deny_groups: node['ssh']['deny_groups'],
+    allow_groups: node['ssh']['allow_groups']
   )
   notifies :restart, 'service[sshd]'
 end

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -425,4 +425,50 @@ describe 'ssh-hardening::server' do
       expect { chef_run }.not_to raise_error
     end
   end
+
+  it 'leaves deny users commented' do
+    expect(chef_run).to render_file('/etc/ssh/sshd_config')
+      .with_content(/#DenyUsers */)
+  end
+
+  it 'leaves allow users commented' do
+    expect(chef_run).to render_file('/etc/ssh/sshd_config')
+      .with_content(/#AllowUsers user1/)
+  end
+
+  it 'leaves deny groups commented' do
+    expect(chef_run).to render_file('/etc/ssh/sshd_config')
+      .with_content(/#DenyGroups */)
+  end
+
+  it 'leaves allow groups commented' do
+    expect(chef_run).to render_file('/etc/ssh/sshd_config')
+      .with_content(/#AllowGroups group1/)
+  end
+
+  context 'with attribute deny_users' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.set['ssh']['deny_users'] = %w(someuser)
+      end.converge(described_recipe)
+    end
+
+    it 'adds user to deny list' do
+      expect(chef_run).to render_file('/etc/ssh/sshd_config')
+        .with_content(/DenyUsers [^#]*\bsomeuser\b/)
+    end
+  end
+
+  context 'with attribute deny_users mutiple' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new do |node|
+        node.set['ssh']['deny_users'] = %w(someuser otheruser)
+      end.converge(described_recipe)
+    end
+
+    it 'adds users to deny list' do
+      expect(chef_run).to render_file('/etc/ssh/sshd_config')
+        .with_content(/DenyUsers [^#]*\bsomeuser otheruser\b/)
+    end
+  end
 end

--- a/templates/default/opensshd.conf.erb
+++ b/templates/default/opensshd.conf.erb
@@ -119,10 +119,26 @@ GSSAPIAuthentication no
 GSSAPICleanupCredentials yes
 
 # In case you don't use PAM (`UsePAM no`), you can alternatively restrict users and groups here. For key-based authentication this is not necessary, since all keys must be explicitely enabled.
+<% unless @node['ssh']['deny_users'].empty? %>
+DenyUsers <%= @node['ssh']['deny_users'].join(' ') %>
+<% else %>
 #DenyUsers *
+<% end %>
+<% unless @node['ssh']['allow_users'].empty? %>
+AllowUsers <%= @node['ssh']['allow_users'].join(' ') %>
+<% else %>
 #AllowUsers user1
+<% end %>
+<% unless @node['ssh']['deny_groups'].empty? %>
+DenyGroups <%= @node['ssh']['deny_groups'].join(' ') %>
+<% else %>
 #DenyGroups *
+<% end %>
+<% unless @node['ssh']['allow_groups'].empty? %>
+AllowGroups <%= @node['ssh']['allow_groups'].join(' ') %>
+<% else %>
 #AllowGroups group1
+<% end %>
 
 
 # Network


### PR DESCRIPTION
This is a pull request to close #75.

Ruby is not my most comfortable language and I did quite some copy and pasting, but we pass all the rake tests.

I also tried to ensure the config file would be identical to the current one if the default attributes were used to prevent noise during chef runs after updating the whatever version this ends up in.